### PR TITLE
Remove Japanese tokenizer - it's crashing.

### DIFF
--- a/tokenisers.py
+++ b/tokenisers.py
@@ -1,7 +1,6 @@
 import re
 import jieba
 import thai_segmenter
-import nagisa
 
 
 def eng(sentence):
@@ -90,14 +89,6 @@ def asm(sentence):
     o = re.sub(r"  *", " ", o)
 
     return [x for x in re.split(" ", o) if not x.strip() == ""]
-
-
-def jpn(sentence):
-    """
-        tokenisers.tokenise("自然消滅することは目に見えてるじゃん。", lang="jpn")
-        ['自然', '消滅', 'する', 'こと', 'は', '目', 'に', '見え', 'てる', 'じゃん', '。']
-    """
-    return nagisa.tagging(sentence).words
 
 
 def kab(sentence):
@@ -342,8 +333,6 @@ def tokenise(sentence, lang):
         return pes(sentence)
     if lang in ["ga", "gle"] or lang.startswith("ga-"):
         return gle(sentence)
-    #     if lang in ["ja", "jpn"]:
-    #         return jpn(sentence)
     if lang in ["kab"]:
         return kab(sentence)
     if lang in ["ka", "kat"]:


### PR DESCRIPTION
We might need to use a different tokenizer library. Here's the crash report:

```
[15:20:19] git:(main*) d33tah@d33tah-pc:/home/d33tah/workspace/omnilingo(0) > gdb python                    
GNU gdb (Ubuntu 9.2-0ubuntu1~20.04) 9.2
Copyright (C) 2020 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
Type "show copying" and "show warranty" for details.
This GDB was configured as "x86_64-linux-gnu".
Type "show configuration" for configuration details.
For bug reporting instructions, please see:
<http://www.gnu.org/software/gdb/bugs/>.
Find the GDB manual and other documentation resources online at:
    <http://www.gnu.org/software/gdb/documentation/>.

For help, type "help".
Type "apropos word" to search for commands related to "word"...
Reading symbols from python...
(No debugging symbols found in python)
(gdb) r question_loader.py
Starting program: /home/d33tah/virtualenv/bin/python question_loader.py
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib/x86_64-linux-gnu/libthread_db.so.1".
[Detaching after fork from child process 14658]
[New Thread 0x7ffff321e700 (LWP 14684)]
[New Thread 0x7ffff2a1d700 (LWP 14685)]
[New Thread 0x7ffff021c700 (LWP 14686)]
[New Thread 0x7fffeba1b700 (LWP 14687)]
[New Thread 0x7fffe921a700 (LWP 14688)]
[New Thread 0x7fffe6a19700 (LWP 14689)]
[New Thread 0x7fffe4218700 (LWP 14690)]
[dynet] random seed: 1234
[dynet] allocating memory: 32MB

Thread 1 "python" received signal SIGILL, Illegal instruction.
0x00007fffdf082476 in dynet::DeviceMempoolSizes::DeviceMempoolSizes(std::string const&) () from /home/d33tah/virtualenv/lib/python3.8/site-packages/dyNET38.libs/libdynet-dbf8d59b.so
(gdb) bt
#0  0x00007fffdf082476 in dynet::DeviceMempoolSizes::DeviceMempoolSizes(std::string const&) () from /home/d33tah/virtualenv/lib/python3.8/site-packages/dyNET38.libs/libdynet-dbf8d59b.so
#1  0x00007fffdf0d32e3 in dynet::initialize(dynet::DynetParams&) () from /home/d33tah/virtualenv/lib/python3.8/site-packages/dyNET38.libs/libdynet-dbf8d59b.so
#2  0x00007fffdf77f3ad in __pyx_f_6_dynet_11DynetParams_init (__pyx_skip_dispatch=1, __pyx_v_self=<optimized out>) at /tmp/pip-req-build-5x6eyi0z/python/_dynet.cpp:8373
#3  __pyx_pf_6_dynet_11DynetParams_6init (__pyx_v_self=<optimized out>) at /tmp/pip-req-build-5x6eyi0z/python/_dynet.cpp:8422
#4  __pyx_pw_6_dynet_11DynetParams_7init (__pyx_v_self=<optimized out>, unused=<optimized out>) at /tmp/pip-req-build-5x6eyi0z/python/_dynet.cpp:8406
#5  0x000000000050425b in ?? ()
#6  0x000000000056a136 in _PyEval_EvalFrameDefault ()
#7  0x000000000056822a in _PyEval_EvalCodeWithName ()
#8  0x000000000068c1e7 in PyEval_EvalCode ()
#9  0x00000000005ff1f4 in ?? ()
#10 0x00000000005c3cb0 in ?? ()
#11 0x00000000005f257d in PyVectorcall_Call ()
#12 0x000000000056fcb6 in _PyEval_EvalFrameDefault ()
#13 0x000000000056822a in _PyEval_EvalCodeWithName ()
#14 0x00000000005f6033 in _PyFunction_Vectorcall ()
#15 0x000000000056ef97 in _PyEval_EvalFrameDefault ()
#16 0x00000000005f5e56 in _PyFunction_Vectorcall ()
#17 0x000000000056a136 in _PyEval_EvalFrameDefault ()
#18 0x00000000005f5e56 in _PyFunction_Vectorcall ()
#19 0x0000000000569f5e in _PyEval_EvalFrameDefault ()
#20 0x00000000005f5e56 in _PyFunction_Vectorcall ()
#21 0x0000000000569f5e in _PyEval_EvalFrameDefault ()
#22 0x00000000005f5e56 in _PyFunction_Vectorcall ()
#23 0x00000000005f3a11 in ?? ()
#24 0x00000000005f3e98 in _PyObject_CallMethodIdObjArgs ()
#25 0x0000000000551493 in PyImport_ImportModuleLevelObject ()
#26 0x000000000056c1e3 in _PyEval_EvalFrameDefault ()
#27 0x000000000056822a in _PyEval_EvalCodeWithName ()
#28 0x000000000068c1e7 in PyEval_EvalCode ()
#29 0x00000000005ff1f4 in ?? ()
#30 0x00000000005c3cb0 in ?? ()
#31 0x00000000005f257d in PyVectorcall_Call ()
#32 0x000000000056fcb6 in _PyEval_EvalFrameDefault ()
#33 0x000000000056822a in _PyEval_EvalCodeWithName ()
#34 0x00000000005f6033 in _PyFunction_Vectorcall ()
#35 0x000000000056ef97 in _PyEval_EvalFrameDefault ()
#36 0x00000000005f5e56 in _PyFunction_Vectorcall ()
#37 0x000000000056a136 in _PyEval_EvalFrameDefault ()
#38 0x00000000005f5e56 in _PyFunction_Vectorcall ()
#39 0x0000000000569f5e in _PyEval_EvalFrameDefault ()
#40 0x00000000005f5e56 in _PyFunction_Vectorcall ()
#41 0x0000000000569f5e in _PyEval_EvalFrameDefault ()
#42 0x00000000005f5e56 in _PyFunction_Vectorcall ()
#43 0x00000000005f3a11 in ?? ()
#44 0x00000000005f3e98 in _PyObject_CallMethodIdObjArgs ()
#45 0x0000000000551493 in PyImport_ImportModuleLevelObject ()
#46 0x000000000056c1e3 in _PyEval_EvalFrameDefault ()
#47 0x000000000056822a in _PyEval_EvalCodeWithName ()
#48 0x000000000068c1e7 in PyEval_EvalCode ()
#49 0x00000000005ff1f4 in ?? ()
#50 0x00000000005c3cb0 in ?? ()
#51 0x00000000005f257d in PyVectorcall_Call ()
#52 0x000000000056fcb6 in _PyEval_EvalFrameDefault ()
#53 0x000000000056822a in _PyEval_EvalCodeWithName ()
#54 0x00000000005f6033 in _PyFunction_Vectorcall ()
#55 0x000000000056ef97 in _PyEval_EvalFrameDefault ()
#56 0x00000000005f5e56 in _PyFunction_Vectorcall ()
--Type <RET> for more, q to quit, c to continue without paging--
#57 0x000000000056a136 in _PyEval_EvalFrameDefault ()
#58 0x00000000005f5e56 in _PyFunction_Vectorcall ()
#59 0x0000000000569f5e in _PyEval_EvalFrameDefault ()
#60 0x00000000005f5e56 in _PyFunction_Vectorcall ()
#61 0x0000000000569f5e in _PyEval_EvalFrameDefault ()
#62 0x00000000005f5e56 in _PyFunction_Vectorcall ()
#63 0x00000000005f3a11 in ?? ()
#64 0x00000000005f3e98 in _PyObject_CallMethodIdObjArgs ()
#65 0x0000000000551493 in PyImport_ImportModuleLevelObject ()
#66 0x000000000056c1e3 in _PyEval_EvalFrameDefault ()
#67 0x000000000056822a in _PyEval_EvalCodeWithName ()
#68 0x000000000068c1e7 in PyEval_EvalCode ()
#69 0x00000000005ff1f4 in ?? ()
#70 0x00000000005c3cb0 in ?? ()
#71 0x00000000005f257d in PyVectorcall_Call ()
#72 0x000000000056fcb6 in _PyEval_EvalFrameDefault ()
#73 0x000000000056822a in _PyEval_EvalCodeWithName ()
#74 0x00000000005f6033 in _PyFunction_Vectorcall ()
#75 0x000000000056ef97 in _PyEval_EvalFrameDefault ()
#76 0x00000000005f5e56 in _PyFunction_Vectorcall ()
#77 0x000000000056a136 in _PyEval_EvalFrameDefault ()
#78 0x00000000005f5e56 in _PyFunction_Vectorcall ()
#79 0x0000000000569f5e in _PyEval_EvalFrameDefault ()
#80 0x00000000005f5e56 in _PyFunction_Vectorcall ()
#81 0x0000000000569f5e in _PyEval_EvalFrameDefault ()
#82 0x00000000005f5e56 in _PyFunction_Vectorcall ()
#83 0x00000000005f3a11 in ?? ()
#84 0x00000000005f3e98 in _PyObject_CallMethodIdObjArgs ()
#85 0x0000000000551493 in PyImport_ImportModuleLevelObject ()
#86 0x000000000056c1e3 in _PyEval_EvalFrameDefault ()
#87 0x000000000056822a in _PyEval_EvalCodeWithName ()
#88 0x000000000068c1e7 in PyEval_EvalCode ()
#89 0x00000000005ff1f4 in ?? ()
#90 0x00000000005c3cb0 in ?? ()
#91 0x00000000005f257d in PyVectorcall_Call ()
#92 0x000000000056fcb6 in _PyEval_EvalFrameDefault ()
#93 0x000000000056822a in _PyEval_EvalCodeWithName ()
#94 0x00000000005f6033 in _PyFunction_Vectorcall ()
#95 0x000000000056ef97 in _PyEval_EvalFrameDefault ()
#96 0x00000000005f5e56 in _PyFunction_Vectorcall ()
#97 0x000000000056a136 in _PyEval_EvalFrameDefault ()
#98 0x00000000005f5e56 in _PyFunction_Vectorcall ()
#99 0x0000000000569f5e in _PyEval_EvalFrameDefault ()
#100 0x00000000005f5e56 in _PyFunction_Vectorcall ()
#101 0x0000000000569f5e in _PyEval_EvalFrameDefault ()
#102 0x00000000005f5e56 in _PyFunction_Vectorcall ()
#103 0x00000000005f3a11 in ?? ()
#104 0x00000000005f3e98 in _PyObject_CallMethodIdObjArgs ()
#105 0x0000000000551493 in PyImport_ImportModuleLevelObject ()
#106 0x000000000056c1e3 in _PyEval_EvalFrameDefault ()
#107 0x000000000056822a in _PyEval_EvalCodeWithName ()
#108 0x000000000068c1e7 in PyEval_EvalCode ()
#109 0x000000000067d5a1 in ?? ()
#110 0x000000000067d61f in ?? ()
#111 0x000000000067d6db in PyRun_FileExFlags ()
#112 0x000000000067da6e in PyRun_SimpleFileExFlags ()
#113 0x00000000006b6132 in Py_RunMain ()
--Type <RET> for more, q to quit, c to continue without paging--
#114 0x00000000006b64bd in Py_BytesMain ()
#115 0x00007ffff7dcc0b3 in __libc_start_main (main=0x4eec80 <main>, argc=2, argv=0x7fffffffdab8, init=<optimized out>, fini=<optimized out>, rtld_fini=<optimized out>, stack_end=0x7fffffffdaa8) at ../csu/libc-start.c:308
#116 0x00000000005f927e in _start ()
(gdb) quit
A debugging session is active.

        Inferior 1 [process 14630] will be killed.

Quit anyway? (y or n) 
Please answer y or n.
A debugging session is active.

        Inferior 1 [process 14630] will be killed.

Quit anyway? (y or n) y
```