### PR TITLE
fix french tokeniser

### DIFF
--- a/lib/tokenisers.py
+++ b/lib/tokenisers.py
@@ -173,7 +173,7 @@ def _cat(sentence):
 def _fra(sentence):
     """Tokeniser for fra."""
     o = sentence
-    o = re.sub(r"([!*+,./:;?@|~¡«°·»¿–—―’“”…]+)", r" \g<1> ", o)
+    o = re.sub(r"([!*+,./\":;?@|~¡«°·»¿–—―’“”…]+)", r" \g<1> ", o)
     o = re.sub(r"([JDLSM]['’])", r"\g<1> ", o)
     o = re.sub(r"( [jdlsm]['’])", r" \g<1> ", o)
     o = re.sub(r"  *", " ", o)


### PR DESCRIPTION
I forgot a punctuation character from the tokeniser:
![imatge](https://user-images.githubusercontent.com/449545/114443747-f5d26100-9bc5-11eb-9d8c-6cb81936d44e.png)
