### PR TITLE
Move language caching out of Makefile.

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,6 +1,12 @@
 # Development Environment Setup
 
-## Using direnv and nix
+## Using poetry
+
+1. [Install poetry](https://python-poetry.org/docs/#installation)
+1. `poetry install`
+1. `poetry shell`
+
+## Optional: Using direnv and nix
 
 If you're using nix and direnv we have the configuration ready to go minus the
 .envrc file you need to kick the process off (you can use another if you prefer

--- a/.github/workflows/python-checks.yml
+++ b/.github/workflows/python-checks.yml
@@ -44,19 +44,17 @@ jobs:
 
             - name: pre-commit
               run: pre-commit run --all-files
-              # - name: vulture
-              #   run: |
-              #     poetry run vulture --min-confidence=61 --exclude=main.py \
-              #     --ignore-names=main
-              # - name: main.py --help
-              #   run: poetry run main.py --help
-              # - name: pytest
-              #   env:
-              #       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-              #   run: |
-              #       poetry run pytest
-              #       #poetry run coveralls
-              # - name: poetry build
-              #   run: |
-              #       poetry build
-              #       tar -zvtf dist/omnilingo-*.tar.gz | grep omnilingo
+            - name: vulture
+              run: poetry run vulture --min-confidence=61 --exclude=omnilingo/main.py --ignore-names=main omnilingo  # yamllint disable-line
+            - name: omnilingo --help
+              run: poetry run omnilingo --help
+            - name: pytest
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: |
+                  poetry run pytest
+                  #poetry run coveralls
+            - name: poetry build
+              run: |
+                  poetry build
+                  tar -zvtf dist/omnilingo-*.tar.gz | grep omnilingo

--- a/Makefile
+++ b/Makefile
@@ -2,16 +2,6 @@ targets=$(foreach l,$(shell cd cv-corpus-6.1-2020-12-11/; ls),static/$(l) cache/
 
 all: $(targets) static/indexes
 
-lib/data/dict/zh:
-	wget -O - https://www.mdbg.net/chinese/export/cedict/cedict_1_0_ts_utf-8_mdbg.txt.gz | zcat > $@
-
-#v-corpus-6.1-2020-12-11/.d:
-#	mkdir -p cv-corpus-6.1-2020-12-11
-#	touch $@
-
-#cv-corpus-6.1-2020-12-11/fi: cv-corpus-6.1-2020-12-11/.d
-#	wget --no-check-certificate http://cl.indiana.edu/~ftyers/cv/cv-corpus-6.1-2020-12-11.tar.gz -O- | tar zxf -
-
 static/indexes: $(targets)
 	mkdir -p static
 	./lib/collect.py ./cache/ ./static/

--- a/README.md
+++ b/README.md
@@ -81,9 +81,11 @@ To bootstrap the project for Finnish, `git clone` the repository, then run the f
 commands:
 
 ```bash
+pip install poetry
 pip install -r requirements.txt
 make
-./main.py
+poetry install
+poetry run omnilingo serve
 ```
 
 The project should be accessible through http://localhost:5001/index.html

--- a/omnilingo/__init__.py
+++ b/omnilingo/__init__.py
@@ -1,0 +1,1 @@
+"""OmniLingo Package."""

--- a/omnilingo/cache.py
+++ b/omnilingo/cache.py
@@ -1,0 +1,39 @@
+"""OmniLingo Cache Management."""
+
+import gzip
+import shutil
+from pathlib import Path
+
+import requests
+from xdg import xdg_cache_home
+
+__all__ = ("DEFAULT_PATH", "clean", "update")
+
+
+def _default_path() -> Path:
+    p = xdg_cache_home() / "omnilingo"
+    p.mkdir(parents=True, exist_ok=True)
+    return p
+
+
+DEFAULT_PATH = _default_path()
+
+
+def clean(path: Path = DEFAULT_PATH) -> None:
+    """Clean the cached language files."""
+    for p in path.glob("*"):
+        shutil.rmtree(p)
+
+
+def update(path: Path = DEFAULT_PATH, force: bool = False) -> None:
+    """Update the cached language files."""
+    if not force and path.is_dir() and len(list(path.glob("*"))):
+        return
+
+    dict_path = path / "lib" / "data" / "dict"
+    dict_path.mkdir(parents=True, exist_ok=True)
+
+    response = requests.get("https://www.mdbg.net/chinese/export/cedict/cedict_1_0_ts_utf-8_mdbg.txt.gz")
+    with open(dict_path / "zh", "wb") as fh:
+        # TODO chunked handling for streaming purposes?
+        fh.write(gzip.decompress(response.content))

--- a/omnilingo/main.py
+++ b/omnilingo/main.py
@@ -1,0 +1,52 @@
+"""OmniLingo CLI Interface."""
+
+from pathlib import Path
+
+import click
+
+import omnilingo.cache as _cache
+import omnilingo.server as server
+
+
+@click.group()
+@click.option(
+    "--cache-path",
+    type=lambda x: Path(click.Path(exists=True, file_okay=False, writable=True)(x)),
+    default=_cache.DEFAULT_PATH,
+    help="Path to cache directory.",
+)
+@click.pass_context
+def main(ctx: click.Context, cache_path: Path) -> None:
+    """Omnilingo Control Commands."""
+    ctx.obj = cache_path
+
+
+@main.command()
+@click.option(
+    "--port",
+    type=click.IntRange(0, 65535),
+    default=5001,
+    help="Port for web server to listen on.",
+    envvar="FLASK_PORT",
+)
+@click.option("--host", default="127.0.0.1", help="IP Aaddress for web server to listen on.")
+@click.pass_obj
+def serve(cache_path: Path, port: int, host: str) -> None:
+    """Start Web Server."""
+    languages = [p.name for p in Path("cache/").glob("*")]
+    click.echo(f"[languages] {languages}")
+    _cache.update(path=cache_path)
+    server.APPLICATION.run(port=port, host=host)
+
+
+@main.command()
+@click.option("--update/--no-update", "-u", is_flag=True, default=False, help="Update the cache if outdated.")
+@click.option("--force/--no-force", "-f", is_flag=True, default=False, help="Force the action even if not needed.")
+@click.option("--clean/--no-clean", is_flag=True, default=False, help="Clean up the cache directory leaving it empty.")
+@click.pass_obj
+def cache(cache_path: Path, update: bool, force: bool, clean: bool) -> None:
+    """Control Language Cache Files."""
+    if update:
+        _cache.update(path=cache_path, force=force)
+    if clean:
+        _cache.clean(path=cache_path)

--- a/omnilingo/server.py
+++ b/omnilingo/server.py
@@ -1,34 +1,30 @@
-#!/usr/bin/env python3
-"""Flask Web Server for omnilingo."""
-
-import os
-from pathlib import Path
+"""Server for OmniLingo."""
 
 from flask import Flask, send_from_directory
 
-app = Flask(__name__, static_url_path="/client")
-app.config["SEND_FILE_MAX_AGE_DEFAULT"] = 0  # For the index
+APPLICATION = Flask("omnilingo", static_url_path="/client")
+APPLICATION.config["SEND_FILE_MAX_AGE_DEFAULT"] = 0  # For the index
 
 
-@app.route("/index.html")
+@APPLICATION.route("/index.html")
 def front():
     """Entrypoint for API."""
     return send_from_directory("client", "index.html")
 
 
-@app.route("/favicon.ico")
+@APPLICATION.route("/favicon.ico")
 def favicon():
     """Favicon for web brwosers."""
     return send_from_directory("client", "favicon.ico")
 
 
-@app.route("/<path:path>")
+@APPLICATION.route("/<path:path>")
 def client(path):
     """Serve Javascript Client."""
     return send_from_directory("client", path)
 
 
-@app.route("/indexes")
+@APPLICATION.route("/indexes")
 def indexes():
     """Serve language indexes."""
     return open("static/indexes").read()
@@ -37,19 +33,13 @@ def indexes():
 #    return send_from_directory("static", "indexes") # FIXME: Stop it caching
 
 
-@app.route("/index/<path:path>")
+@APPLICATION.route("/index/<path:path>")
 def index(path):
     """Index of static files."""
     return send_from_directory("static/index/", path)
 
 
-@app.route("/static/<path:path>")
+@APPLICATION.route("/static/<path:path>")
 def serve_static(path):
     """Serve static assets."""
     return send_from_directory("static", path)
-
-
-if __name__ == "__main__":
-    languages = [p.name for p in Path("cache/").glob("*")]
-    print("[languages]", languages)
-    app.run(port=int(os.environ.get("FLASK_PORT", "5001")), host="127.0.0.1")

--- a/omnilingo_test/__init__.py
+++ b/omnilingo_test/__init__.py
@@ -1,0 +1,1 @@
+"""OmniLingo Tests."""

--- a/omnilingo_test/main_test.py
+++ b/omnilingo_test/main_test.py
@@ -1,0 +1,19 @@
+"""OmniLingo Main CLI Behaviour Tests."""
+
+from click.testing import CliRunner
+
+import omnilingo.main as sut
+
+
+def test_main_help() -> None:
+    """Test main --help."""
+    runner = CliRunner()
+    result = runner.invoke(sut.main, ["--help"])
+    assert result.exit_code == 0
+
+
+def test_cache_help() -> None:
+    """Test main cache --help."""
+    runner = CliRunner()
+    result = runner.invoke(sut.main, ["cache", "--help"])
+    assert result.exit_code == 0

--- a/poetry.lock
+++ b/poetry.lock
@@ -30,7 +30,7 @@ tests = ["coverage (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six
 tests_no_zope = ["coverage (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six"]
 
 [[package]]
-category = "dev"
+category = "main"
 description = "Python package for providing Mozilla's CA Bundle."
 name = "certifi"
 optional = false
@@ -46,7 +46,7 @@ python-versions = ">=3.6.1"
 version = "3.2.0"
 
 [[package]]
-category = "dev"
+category = "main"
 description = "Universal encoding detector for Python 2 and 3"
 name = "chardet"
 optional = false
@@ -65,7 +65,7 @@ version = "1.7.0"
 six = "*"
 
 [[package]]
-category = "dev"
+category = "main"
 description = "Composable command line interface toolkit"
 name = "click"
 optional = false
@@ -163,7 +163,7 @@ version = "2.2.2"
 license = ["editdistance-s"]
 
 [[package]]
-category = "dev"
+category = "main"
 description = "Internationalized Domain Names in Applications (IDNA)"
 name = "idna"
 optional = false
@@ -372,7 +372,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
 version = "5.4.1"
 
 [[package]]
-category = "dev"
+category = "main"
 description = "Python HTTP for Humans."
 name = "requests"
 optional = false
@@ -427,7 +427,7 @@ python-versions = "*"
 version = "3.7.4.3"
 
 [[package]]
-category = "dev"
+category = "main"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 name = "urllib3"
 optional = false
@@ -485,6 +485,14 @@ dev = ["pytest", "pytest-timeout", "coverage", "tox", "sphinx", "pallets-sphinx-
 watchdog = ["watchdog"]
 
 [[package]]
+category = "main"
+description = "Variables defined by the XDG Base Directory Specification"
+name = "xdg"
+optional = false
+python-versions = ">=3.6,<4.0"
+version = "5.0.1"
+
+[[package]]
 category = "dev"
 description = "Backport of pathlib-compatible object wrapper for zip files"
 marker = "python_version < \"3.8\""
@@ -498,7 +506,7 @@ docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
 testing = ["pytest (>=4.6)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "pytest-enabler", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
 
 [metadata]
-content-hash = "54b9f78e4f92e59f988b726c091fe354799e00c5bd6efbbfca796b0cf0dee110"
+content-hash = "6151a06b7165509211e6bdcbec25727f1d92b4a52617f231a1f2d1001fbc849f"
 lock-version = "1.0"
 python-versions = "^3.7"
 
@@ -790,6 +798,10 @@ vulture = [
 werkzeug = [
     {file = "Werkzeug-1.0.1-py2.py3-none-any.whl", hash = "sha256:2de2a5db0baeae7b2d2664949077c2ac63fbd16d98da0ff71837f7d1dea3fd43"},
     {file = "Werkzeug-1.0.1.tar.gz", hash = "sha256:6c80b1e5ad3665290ea39320b91e1be1e0d5f60652b964a3070216de83d2e47c"},
+]
+xdg = [
+    {file = "xdg-5.0.1-py3-none-any.whl", hash = "sha256:9ddd6649bee9148f952305603a08474e3ef37c909eb19dfcb9737d54ebcc407e"},
+    {file = "xdg-5.0.1.tar.gz", hash = "sha256:97a27058caa61b4ce04e05471643caa6bc8c563d2638f92c0516ac50208146d8"},
 ]
 zipp = [
     {file = "zipp-3.4.1-py3-none-any.whl", hash = "sha256:51cb66cc54621609dd593d1787f286ee42a5c0adbb4b29abea5a63edc3e03098"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -780,31 +780,36 @@ classifiers = [
   "Typing :: Typed",
 ]
 packages = [
+  { include = "omnilingo" },
 ]
 
 [tool.poetry.dependencies]
+click = "^7.1.2"
+flask = "^1.1.2"
 python = "^3.7"
+requests = "^2.25.1"
+xdg = "^5.0.1"
 
 [tool.poetry.dev-dependencies]
+cjktools = "^1.7.0"
 coveralls = "^2.1.1"
-pip = "^20.2.4"
-pre-commit = "^2.7.1"
-pytest = "^6.1.1"
-pytest-cov = "^2.10.0"
-vulture = "^2.0"
-flask = "^1.1.2"
 jieba = "^0.42.1"
 mutagen = "^1.45.1"
-thai-segmenter = "^0.4.1"
+pip = "^20.2.4"
+pre-commit = "^2.7.1"
 pybktree = "^1.1"
-cjktools = "^1.7.0"
+pytest = "^6.1.1"
+pytest-cov = "^2.10.0"
+thai-segmenter = "^0.4.1"
+vulture = "^2.0"
 
 [tool.poetry.scripts]
+omnilingo = "omnilingo.main:main"
 
 [tool.pytest.ini_options]
-addopts = "--doctest-modules --cov=zfs --cov-report=term-missing"
+addopts = "--doctest-modules --cov=omnilingo --cov-report=term-missing"
 testpaths = [
-  "zfs_test",
+  "omnilingo_test",
 ]
 
 [tool.skjold]


### PR DESCRIPTION
This move the project structure just enough to make serving the flask
app packaged and cache the language contents.  This starts to solify on
poetry as the only tool (not ready for several more changes).

This does start establishing omnilingo as the command that controls the
rest of the processing.

This is missing some behavioural testing that the web server actually
does what it should and probably needs to be added so that refactors
like this don't break everything.