### PR TITLE
Add html lint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -141,7 +141,7 @@ repos:
           - id: toml-sort
             args: [--in-place]
     - repo: https://github.com/executablebooks/mdformat
-      rev: 0.6.4
+      rev: 0.7.1
       hooks:
           - id: mdformat
             additional_dependencies:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -146,3 +146,16 @@ repos:
           - id: mdformat
             additional_dependencies:
                 - mdformat-tables
+    - repo: https://github.com/Lucas-C/pre-commit-hooks-lxml
+      rev: v1.1.0
+      hooks:
+          - id: forbid-html-img-without-alt-text
+          - id: forbid-non-std-html-attributes
+          - id: detect-missing-css-classes
+            args:
+                - --css-files-dir
+                - .
+                - --html-files-dir
+                - .
+          - id: html-tags-blacklist
+          - id: html-attributes-blacklist


### PR DESCRIPTION
This adds a set of pre-commit hooks pointed at HTML files since I've stumbled across some that exist.  This will ensure we have a base line for additional checks on HTML in the future.